### PR TITLE
Skip dotfiles in live tracks directories

### DIFF
--- a/pp_livelist.py
+++ b/pp_livelist.py
@@ -166,7 +166,7 @@ class LiveList(object):
                 track_file = self.pp_live_dir1 + os.sep + track_file
                 (root_name,leaf)=os.path.split(track_file)
                 if leaf[0] == '.':
-                    break
+                    continue
                 else:
                     (root_file,ext_file)= os.path.splitext(track_file)
                     if (ext_file.lower() in PPdefinitions.IMAGE_FILES+PPdefinitions.VIDEO_FILES+PPdefinitions.AUDIO_FILES) or (ext_file.lower()=='.cfg'):
@@ -177,7 +177,7 @@ class LiveList(object):
                 track_file = self.pp_live_dir2 + os.sep + track_file
                 (root_name,leaf)=os.path.split(track_file)
                 if leaf[0] == '.':
-                    break
+                    continue
                 else:
                     (root_file,ext_file)= os.path.splitext(track_file)
                     if (ext_file.lower() in PPdefinitions.IMAGE_FILES+PPdefinitions.VIDEO_FILES+PPdefinitions.AUDIO_FILES) or (ext_file.lower()=='.cfg'):


### PR DESCRIPTION
Currently, dotfiles (e.g. `.sync`) in live tracks directories cause the show to end (or repeat) even if there are tracks remaining to be played.  Using `continue` instead of `break` skips the dotfiles and continues to other tracks.

I encountered this situation when a live track directory contained a dotfile for a syncing service (Resilio Sync), but there are any number of reasons dotfiles might exist in the live track directory.  They should be ignored without disrupting playback of other tracks.