### PR TITLE
Bugfix on pp_imageplayer.py

### DIFF
--- a/pp_imageplayer.py
+++ b/pp_imageplayer.py
@@ -412,7 +412,7 @@ class ImagePlayer(Player):
             # no window
             has_window=False
             if len(fields) == 2:
-                image_filter=fields[1]
+                image_filter='Image.'+fields[1]
             else:
                 image_filter='Image.NEAREST'
             return 'normal','',fields[0],has_window,0,0,0,0,image_filter


### PR DESCRIPTION
When Image algorithm is specified error occurs due to missing 'Image.' prefix in code.