### PR TITLE
Updated Python packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Pi Presents MUST have the latest version of omxplayer and of Raspbian, get this 
 
 Install required packages 
 -----------------------------
-         sudo apt-get install python-imaging
-         sudo apt-get install python-imaging-tk
+         sudo apt-get install python-pil
+         sudo apt-get install python-pil.imagetk
          sudo apt-get install unclutter
          sudo apt-get install mplayer
          sudo apt-get install uzbl


### PR DESCRIPTION
Python has removed two of the packages detailed in the Readme.md file.  Updated this to the two current packages.
Removed python-imaging and python-imaging-tk
Added python-pil and python-pil.imagetk

Pipresents runs fine with these latest packages installed. No changes are needed to the code, just to the installation procedure.